### PR TITLE
[holla][김봉철] add: 카카오 소셜 로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -365,4 +365,3 @@ zsdoc/data
 my_settings.py
 csv/
 db_uploader.py
-*.sql

--- a/holla/settings.py
+++ b/holla/settings.py
@@ -10,8 +10,8 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 
-from pathlib import Path
-from my_settings    import DATABASES, SECRET_KEY
+from pathlib        import Path
+from my_settings    import DATABASES, SECRET_KEY, ALGORITHM
 
 import pymysql
 
@@ -25,12 +25,11 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = SECRET_KEY
-
+ALGORITHM = ALGORITHM
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
 ALLOWED_HOSTS = ['*']
-
 
 # Application definition
 

--- a/holla/urls.py
+++ b/holla/urls.py
@@ -2,4 +2,5 @@ from django.urls import path, include
 
 urlpatterns = [
     path('products', include('products.urls')),
+    path('users', include('users.urls'))
 ]

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,3 +1,110 @@
-from django.test import TestCase
+import unittest, jwt
 
-# Create your tests here.
+from django.http    import response
+from django.test    import TestCase, Client
+from unittest.mock  import patch, MagicMock
+
+from users.models   import User
+from django.conf    import settings
+
+class KakaoSignInTest(TestCase):
+    def setUp(self):
+        User.objects.create(
+            id = 1,
+            nickname = "카카오",
+            name = "병철쓰",
+            email = "wecode_kakao@naver.com",
+            kakao_id = 234234
+        )
+        
+    def tearDown(self):
+        User.objects.all().delete()
+
+    @patch('users.views.requests')
+    def test_get_kakao_signin_user_exist_success(self, mocked_requests):
+        client = Client()
+        class MockedResponse:
+            def json(self):
+                return {
+                    'id'          : 234234, 
+                    'connected_at': '2020-12-03T05:31:36Z', 
+                    'properties'  : {
+                        'nickname'         : '병철쓰', 
+                        'profile_image'    : 'http://k.kakaocdn.net/dn/bOugw5/btqJWTqzK7X/HG32V3SaqKbtNGIVl0dgKK/img_640x640.jpg', 
+                        'thumbnail_image'  : 'http://k.kakaocdn.net/dn/bOugw5/btqJWTqzK7X/HG32V3SaqKbtNGIVl0dgKK/img_110x110.jpg'}, 
+                        'kakao_account': {
+                            'profile_needs_agreement': False, 
+                            'profile': {
+                                'nickname': '병철쓰', 
+                                'thumbnail_image_url': 'http://123123.jpg', 
+                                'profile_image_url': 'http://234234243.jpg', 
+                        'is_default_image' : False
+                        }, 
+                        'has_email'            : True, 
+                        'email_needs_agreement': False, 
+                        'is_email_valid'       : True, 
+                        'is_email_verified'    : True, 
+                        'email'                : 'wecode_kakao@naver.com'
+                        }}
+ 
+        results = {
+            "name"  : "병철쓰",
+            "email" : "wecode_kakao@naver.com"
+        }
+
+        mocked_requests.get = MagicMock(return_value = MockedResponse())
+        headers             = {"HTTP_Authorization" : "guraDFDDGH454398"}
+        access_token        = jwt.encode({"id" : 1}, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+        response            = client.get("/users/kakao/signin", **headers)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"message" : "SUCCESS", "results" : results, "access_token" : access_token})
+
+    @patch('users.views.requests')
+    def test_get_kakao_signin_user_not_exist_success(self, mocked_requests):
+        client = Client()
+        class MockedResponse:
+            def json(self):
+                return {
+                    'id'          : 1547717464, 
+                    'connected_at': '2020-12-03T05:31:36Z', 
+                    'properties'  : {
+                        'nickname'         : '김코드', 
+                        'profile_image'    : 'http://k.kakaocdn.net/dn/bOugw5/btqJWTqzK7X/HG32V3SaqKbtNGIVl0dgKK/img_640x640.jpg', 
+                        'thumbnail_image'  : 'http://k.kakaocdn.net/dn/bOugw5/btqJWTqzK7X/HG32V3SaqKbtNGIVl0dgKK/img_110x110.jpg'}, 
+                        'kakao_account': {
+                            'profile_needs_agreement': False, 
+                            'profile': {
+                                'nickname': '김코드', 
+                                'thumbnail_image_url': 'http://123123.jpg', 
+                                'profile_image_url': 'http://234234243.jpg', 
+                        'is_default_image' : False
+                        }, 
+                        'has_email'            : True, 
+                        'email_needs_agreement': False, 
+                        'is_email_valid'       : True, 
+                        'is_email_verified'    : True, 
+                        'email'                : 'wecode10101010@gmail.com'
+                        }}
+      
+        results = {
+            "name"  : "김코드",
+            "email" : "wecode10101010@gmail.com"
+        }
+        
+        mocked_requests.get = MagicMock(return_value = MockedResponse())
+        headers             = {"HTTP_Authorization" : "guraDFDDGH454398"}
+        access_token        = jwt.encode({"id" : 2}, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+        response            = client.get("/users/kakao/signin", **headers)
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json(), {"message" : "SUCCESS", "results" : results, "access_token" : access_token})        
+
+    @patch('users.views.requests')
+    def test_kakao_signin_exist_not_token_failed(self, mocked_requests):
+        client = Client()
+        headers  = {}
+        response = client.get("/users/kakao/signin", **headers)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"message" : "KEY_ERROR"})        

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from users.views import KakaoSignInView
+
+urlpatterns = [
+    path('/kakao/signin', KakaoSignInView.as_view()),
+] 

--- a/users/views.py
+++ b/users/views.py
@@ -1,3 +1,46 @@
-from django.shortcuts import render
+import requests, jwt
 
-# Create your views here.
+from django.http.response import JsonResponse
+from django.views         import View
+
+from users.models         import User
+from django.conf          import settings
+
+class KakaoSignInView(View):
+    def get(self, request):
+        try:
+            access_token   = request.headers["Authorization"]
+            
+            kakao_response = requests.get("https://kapi.kakao.com/v2/user/me", \
+                headers={"Authorization": f"Bearer {access_token}"})
+            
+            kakao_data = kakao_response.json()
+            
+            kakao_id   = kakao_data["id"]
+            email      = kakao_data["kakao_account"]["email"]
+            nickname   = kakao_data["properties"]["nickname"]
+
+            obj, created = User.objects.get_or_create(
+                kakao_id = kakao_id,
+                email    = email,
+                name     = nickname
+            )
+            
+            status_code = 201 if created else 200
+
+            results = {
+                "name"  : obj.name,
+                "email" : obj.email
+            }
+
+            jwt_payload  = {"id" : obj.id}
+            access_token = jwt.encode(jwt_payload, settings.SECRET_KEY, algorithm = settings.ALGORITHM)
+            
+            return JsonResponse({
+                    "message" : "SUCCESS", 
+                    "results" : results, 
+                    "access_token": access_token
+                }, status=status_code)
+
+        except KeyError:
+            return JsonResponse({"message" : "TOKEN_OR_KEY_ERROR"}, status = 400)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 카카오 로그인 api를 이용한 소셜 로그인 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
- 프론트로부터 유효한 액세스 토큰을 헤더로 받아 카카오 서버와 통신을 통해 
토큰의 사용자 정보를 받아옵니다.
받아온 사용자 정보와 서버 db의 데이터를 get or create 구문으로 비교하여 
사용자가 있다면 바로 jwt encode로 토큰을 생성해 반환하고 
사용자가 없다면 db에 사용자 정보를 넣은 후 토큰을 생성해 프론트로 반환합니다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 카카오 로그인 api의 전체적인 flow를 알 수 있었고 사용 방법을 알았습니다.
- get or create 사용 방법을 익혔습니다. 간결한 코드 작성에 유용한 것 같습니다.

<br />

## :: 기타 질문 및 특이 사항
- 카카오로부터 받는 액세스 토큰의 사용자 정보가 비어 있는 문제의 해결이 안 돼 궁금합니다.
- 카카오 싱크를 통해 뭔가를 해야 한다고 하는데 시간 날 때 해결해 보겠습니다.
